### PR TITLE
Feature/js package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Join our Discord community for discussions, support, and updates:
 - **CI/CD integration** with GitHub Actions, GitLab CI, and CircleCI
 - **Specialized integrations** for HuggingFace, PyTorch, Vercel, and Cloudflare
 - **Advanced NPX analysis** with per-package visibility and stale detection
+- **JavaScript package managers**: npm, pnpm, yarn global and project caches (opt-in via `--js-pm`)
 - **Enhanced edge cache purging** with improved API integration
 - **System diagnostics** with `--doctor` command
 
@@ -77,6 +78,18 @@ cargo install cachekill
 ./target/release/cachekill --npx --stale-days 7 --force  # Surgical - only stale packages
 ```
 
+### JavaScript Package Managers usage
+```bash
+# Include JavaScript package manager caches (npm, pnpm, yarn)
+./target/release/cachekill --list --js-pm
+
+# JSON output including JS PM caches
+./target/release/cachekill --list --json --js-pm
+
+# Dry run including JS PM caches
+./target/release/cachekill --dry-run --js-pm
+```
+
 ## Supported Languages
 
 - **JavaScript/TypeScript**: `node_modules/`, `.next/`, `.vite/`
@@ -84,6 +97,7 @@ cargo install cachekill
 - **Rust**: `target/`, `.cargo/`
 - **Java**: `.gradle/`, `build/`, `~/.m2/repository`
 - **Machine Learning**: `~/.cache/huggingface`, `~/.cache/torch`
+- **JavaScript package managers**: npm (`~/.npm` or `%LOCALAPPDATA%\npm-cache`), pnpm (store + meta caches), yarn (global + project `.yarn/cache`)
 - **NPX**: `~/.npm/_npx`
 - **Docker**: Images, containers, volumes
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -380,6 +380,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ pub struct CliArgs {
     pub npx: bool,
     pub restore_last: bool,
     pub all: bool,
+    pub js_pm: bool,
 }
 
 /// Merged configuration combining config file and CLI args
@@ -82,6 +83,7 @@ pub struct MergedConfig {
     pub npx: bool,
     pub restore_last: bool,
     pub all: bool,
+    pub js_pm: bool,
 }
 
 impl Config {
@@ -152,6 +154,7 @@ impl Config {
             npx: cli_args.npx || self.include_npx.unwrap_or(false),
             restore_last: cli_args.restore_last,
             all: cli_args.all,
+            js_pm: cli_args.js_pm,
         }
     }
 }
@@ -173,6 +176,7 @@ impl Default for MergedConfig {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         }
     }
 }
@@ -235,6 +239,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         };
 
         let merged = config.merge_with_cli(&cli_args);
@@ -284,6 +289,7 @@ include_docker = true
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         };
 
         let node_modules = std::path::Path::new("/project/node_modules");

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -506,6 +506,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         };
         
         let result = DiscoveryResult::discover(&config).unwrap();

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -367,6 +367,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         }
     }
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -276,6 +276,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         }
     }
 

--- a/src/npx.rs
+++ b/src/npx.rs
@@ -327,6 +327,7 @@ mod tests {
             npx: false,
             restore_last: false,
             all: false,
+            js_pm: false,
         }
     }
 

--- a/src/package_managers/common.rs
+++ b/src/package_managers/common.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+use crate::cache_entry::{CacheEntry, CacheKind, PlannedAction};
+use crate::config::MergedConfig;
+use crate::util::{get_most_recent_mtime, get_size, is_dir, path_exists};
+
+pub fn planned_action(_config: &MergedConfig) -> PlannedAction {
+    /*
+     * These are not backed up.
+     * Reason: No direct effect on any project, safe to delete
+     */
+
+    PlannedAction::Delete
+}
+
+pub fn make_entry(dir: PathBuf, config: &MergedConfig) -> Result<CacheEntry> {
+    let size = get_size(&dir)?;
+    let last_used: DateTime<Utc> = get_most_recent_mtime(&dir)?;
+    let stale = (Utc::now() - last_used).num_days() > config.stale_days as i64;
+    Ok(
+        CacheEntry::new(dir, CacheKind::JavaScript, size, last_used, stale)
+            .with_planned_action(planned_action(config)),
+    )
+}
+
+pub fn existing_dir(p: &Path) -> bool {
+    path_exists(p) && is_dir(p)
+}

--- a/src/package_managers/mod.rs
+++ b/src/package_managers/mod.rs
@@ -1,0 +1,50 @@
+pub mod common;
+pub mod npm;
+pub mod pnpm;
+pub mod traits;
+pub mod yarn;
+
+use crate::cache_entry::CacheEntry;
+use crate::config::MergedConfig;
+use anyhow::Result;
+use traits::CacheManager;
+
+pub struct PackageManagers {
+    config: MergedConfig,
+}
+
+impl PackageManagers {
+    pub fn new(config: MergedConfig) -> Self {
+        Self { config }
+    }
+
+    fn managers(&self) -> Vec<Box<dyn CacheManager>> {
+        vec![
+            Box::new(npm::NpmManager::new(self.config.clone())),
+            Box::new(pnpm::PnpmManager::new(self.config.clone())),
+            Box::new(yarn::YarnManager::new(self.config.clone())),
+        ]
+    }
+
+    pub fn list_all(&self) -> Result<Vec<CacheEntry>> {
+        let managers: Vec<Box<dyn CacheManager>> = self.managers();
+        let mut all = Vec::new();
+        for m in managers {
+            let mut entries = m.list()?;
+            all.append(&mut entries);
+        }
+        Ok(all)
+    }
+}
+
+/*
+Utils for `handle_cleanup_mode`, `handle_dry_run_mode` & `handle_list_mode`
+Purpose: readability - the function is too cluttered and need refactoring for future.
+ */
+pub fn add_js_pm_entries(entries: &mut Vec<CacheEntry>, config: &MergedConfig) -> Result<()> {
+    if !config.js_pm { return Ok(()); }
+    let pm = PackageManagers::new(config.clone());
+    let mut pm_entries = pm.list_all()?;
+    entries.append(&mut pm_entries);
+    Ok(())
+}

--- a/src/package_managers/mod.rs
+++ b/src/package_managers/mod.rs
@@ -48,3 +48,18 @@ pub fn add_js_pm_entries(entries: &mut Vec<CacheEntry>, config: &MergedConfig) -
     entries.append(&mut pm_entries);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_js_pm_entries_is_noop_when_flag_is_false() {
+        let mut entries = Vec::new();
+        let mut cfg = MergedConfig::default();
+        cfg.js_pm = false;
+        let res = add_js_pm_entries(&mut entries, &cfg);
+        assert!(res.is_ok());
+        assert!(entries.is_empty());
+    }
+}

--- a/src/package_managers/npm.rs
+++ b/src/package_managers/npm.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+use crate::cache_entry::CacheEntry;
+use crate::config::MergedConfig;
+
+use super::common::{existing_dir, make_entry};
+use super::traits::CacheManager;
+
+pub struct NpmManager {
+    pub(crate) config: MergedConfig,
+}
+
+impl NpmManager {
+    pub fn new(config: MergedConfig) -> Self {
+        Self { config }
+    }
+
+    fn cache_dir() -> Option<PathBuf> {
+        #[cfg(target_os = "windows")]
+        {
+            std::env::var_os("LOCALAPPDATA").map(|local| Path::new(&local).join("npm-cache"))
+        }
+        #[cfg(target_os = "macos")]
+        {
+            dirs::home_dir().map(|home| home.join(".npm"))
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            dirs::home_dir().map(|home| home.join(".npm"))
+        }
+    }
+}
+
+impl CacheManager for NpmManager {
+    fn name(&self) -> &'static str {
+        "npm"
+    }
+
+    fn list(&self) -> Result<Vec<CacheEntry>> {
+        let mut entries = Vec::new();
+        if let Some(dir) = Self::cache_dir() {
+            if existing_dir(&dir) {
+                entries.push(make_entry(dir, &self.config)?);
+            }
+        }
+        Ok(entries)
+    }
+
+    fn exclude_patterns(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        if let Some(dir) = Self::cache_dir() {
+            patterns.push(dir.to_string_lossy().to_string());
+        }
+        patterns
+    }
+}

--- a/src/package_managers/pnpm.rs
+++ b/src/package_managers/pnpm.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+use crate::cache_entry::CacheEntry;
+use crate::config::MergedConfig;
+
+use super::common::{existing_dir, make_entry};
+use super::traits::CacheManager;
+
+pub struct PnpmManager {
+    pub(crate) config: MergedConfig,
+}
+
+impl PnpmManager {
+    pub fn new(config: MergedConfig) -> Self {
+        Self { config }
+    }
+}
+
+fn store_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("LOCALAPPDATA")
+            .map(|local| Path::new(&local).join("pnpm").join("store").join("v3"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir().map(|home| home.join("Library").join("pnpm").join("store").join("v3"))
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        dirs::home_dir().map(|home| home.join(".local").join("share").join("pnpm").join("store").join("v3"))
+    }
+}
+
+fn meta_cache_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("LOCALAPPDATA").map(|local| Path::new(&local).join("pnpm-cache"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir().map(|home| home.join("Library").join("Caches").join("pnpm"))
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        dirs::home_dir().map(|home| home.join(".cache").join("pnpm"))
+    }
+}
+
+impl CacheManager for PnpmManager {
+    fn name(&self) -> &'static str {
+        "pnpm"
+    }
+
+    fn list(&self) -> Result<Vec<CacheEntry>> {
+        let mut entries = Vec::new();
+        if let Some(dir) = store_dir() {
+            if existing_dir(&dir) {
+                entries.push(make_entry(dir, &self.config)?);
+            }
+        }
+        if let Some(dir) = meta_cache_dir() {
+            if existing_dir(&dir) {
+                entries.push(make_entry(dir, &self.config)?);
+            }
+        }
+        Ok(entries)
+    }
+
+    fn exclude_patterns(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        if let Some(d) = store_dir() {
+            patterns.push(d.to_string_lossy().to_string());
+        }
+        if let Some(d) = meta_cache_dir() {
+            patterns.push(d.to_string_lossy().to_string());
+        }
+        patterns
+    }
+}

--- a/src/package_managers/traits.rs
+++ b/src/package_managers/traits.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use crate::cache_entry::CacheEntry;
+
+/// Trait implemented by each package manager cache handler
+pub trait CacheManager {
+    /// A short static name (e.g., "npm", "pnpm", "yarn")
+    #[allow(dead_code)]
+    fn name(&self) -> &'static str;
+
+    /// List cache entries for this package manager
+    fn list(&self) -> Result<Vec<CacheEntry>>;
+
+    /// Paths/patterns that should be excluded from backups
+    #[allow(dead_code)]
+    fn exclude_patterns(&self) -> Vec<String>;
+}

--- a/src/package_managers/yarn.rs
+++ b/src/package_managers/yarn.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+use crate::cache_entry::CacheEntry;
+use crate::config::MergedConfig;
+
+use super::common::{existing_dir, make_entry};
+use super::traits::CacheManager;
+
+pub struct YarnManager {
+    pub(crate) config: MergedConfig,
+}
+
+impl YarnManager {
+    pub fn new(config: MergedConfig) -> Self {
+        Self { config }
+    }
+}
+
+fn global_cache_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("LOCALAPPDATA").map(|local| Path::new(&local).join("Yarn").join("Cache"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir().map(|home| home.join("Library").join("Caches").join("Yarn"))
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        dirs::home_dir().map(|home| home.join(".cache").join("yarn"))
+    }
+}
+
+fn project_cache_dir() -> Option<PathBuf> {
+    if let Ok(cwd) = std::env::current_dir() {
+        let p = cwd.join(".yarn").join("cache");
+        if p.exists() && p.is_dir() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+impl CacheManager for YarnManager {
+    fn name(&self) -> &'static str {
+        "yarn"
+    }
+
+    fn list(&self) -> Result<Vec<CacheEntry>> {
+        let mut entries = Vec::new();
+        if let Some(dir) = global_cache_dir() {
+            if existing_dir(&dir) {
+                entries.push(make_entry(dir, &self.config)?);
+            }
+        }
+        if let Some(dir) = project_cache_dir() {
+            if existing_dir(&dir) {
+                entries.push(make_entry(dir, &self.config)?);
+            }
+        }
+        Ok(entries)
+    }
+
+    fn exclude_patterns(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        if let Some(d) = global_cache_dir() {
+            patterns.push(d.to_string_lossy().to_string());
+        }
+        if let Some(d) = project_cache_dir() {
+            patterns.push(d.to_string_lossy().to_string());
+        }
+        patterns
+    }
+}

--- a/tests/js_pm_e2e.rs
+++ b/tests/js_pm_e2e.rs
@@ -1,0 +1,139 @@
+use std::{env, fs};
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn manifest_path() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    p.to_string_lossy().to_string()
+}
+
+fn run_with_env_and_cwd(cwd: &std::path::Path, envs: &[(&str, &std::path::Path)], extra_args: &[&str]) -> (bool, String, String) {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run").arg("--manifest-path").arg(manifest_path()).arg("--");
+    for a in extra_args { cmd.arg(a); }
+    cmd.current_dir(cwd);
+    for (k, v) in envs { cmd.env(k, v); }
+    let output = cmd.output().expect("failed to run cachekill");
+    (output.status.success(), String::from_utf8_lossy(&output.stdout).to_string(), String::from_utf8_lossy(&output.stderr).to_string())
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn js_pm_end_to_end_windows() {
+    // Fake global caches under LOCALAPPDATA
+    let td = TempDir::new().unwrap();
+    let base = td.path();
+    fs::create_dir_all(base.join("npm-cache")).unwrap();
+    fs::create_dir_all(base.join("pnpm").join("store").join("v3")).unwrap();
+    fs::create_dir_all(base.join("pnpm-cache")).unwrap();
+    fs::create_dir_all(base.join("Yarn").join("Cache")).unwrap();
+
+    // Fake project local Yarn cache by setting CWD
+    let proj = TempDir::new().unwrap();
+    fs::create_dir_all(proj.path().join(".yarn").join("cache")).unwrap();
+
+    // With --js-pm we should see the seeded paths
+    let (ok, out, err) = run_with_env_and_cwd(
+        proj.path(),
+        &[("LOCALAPPDATA", base)],
+        &["--list", "--json", "--js-pm"],
+    );
+    assert!(ok, "command failed on Windows. stderr=\n{}\nstdout=\n{}", err, out);
+
+    assert!(out.contains("npm-cache"), "missing npm-cache entry. out=\n{}", out);
+    assert!(out.contains("pnpm\\store\\v3"), "missing pnpm store v3 entry. out=\n{}", out);
+    assert!(out.contains("pnpm-cache"), "missing pnpm-cache entry. out=\n{}", out);
+    assert!(out.contains("Yarn\\Cache") || out.contains("Yarn/Cache"), "missing Yarn global cache. out=\n{}", out);
+    assert!(out.contains(".yarn\\cache") || out.contains(".yarn/cache"), "missing Yarn project cache. out=\n{}", out);
+
+    // Without --js-pm these specific entries must not appear
+    let (ok2, out2, err2) = run_with_env_and_cwd(
+        proj.path(),
+        &[("LOCALAPPDATA", base)],
+        &["--list", "--json"],
+    );
+    assert!(ok2, "command (no --js-pm) failed on Windows. stderr=\n{}\nstdout=\n{}", err2, out2);
+
+    for needle in ["npm-cache", "pnpm\\store\\v3", "pnpm-cache", "Yarn\\Cache", ".yarn\\cache"] {
+        assert!(!out2.contains(needle), "unexpected JS PM entry '{}' found without --js-pm. out=\n{}", needle, out2);
+    }
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn js_pm_end_to_end_macos() {
+    let td = TempDir::new().unwrap();
+    let home = td.path();
+    // Seed expected macOS locations
+    fs::create_dir_all(home.join(".npm")).unwrap();
+    fs::create_dir_all(home.join("Library").join("pnpm").join("store").join("v3")).unwrap();
+    fs::create_dir_all(home.join("Library").join("Caches").join("pnpm")).unwrap();
+    fs::create_dir_all(home.join("Library").join("Caches").join("Yarn")).unwrap();
+
+    let proj = TempDir::new().unwrap();
+    fs::create_dir_all(proj.path().join(".yarn").join("cache")).unwrap();
+
+    let (ok, out, err) = run_with_env_and_cwd(
+        proj.path(),
+        &[("HOME", home)],
+        &["--list", "--json", "--js-pm"],
+    );
+    assert!(ok, "command failed on macOS. stderr=\n{}\nstdout=\n{}", err, out);
+
+    assert!(out.contains("/.npm") || out.contains("\\.npm"), "missing ~/.npm entry. out=\n{}", out);
+    assert!(out.contains("Library/pnpm/store/v3") || out.contains("Library\\pnpm\\store\\v3"), "missing pnpm store v3 entry. out=\n{}", out);
+    assert!(out.contains("Library/Caches/pnpm") || out.contains("Library\\Caches\\pnpm"), "missing pnpm meta cache. out=\n{}", out);
+    assert!(out.contains("Library/Caches/Yarn") || out.contains("Library\\Caches\\Yarn"), "missing Yarn global cache. out=\n{}", out);
+    assert!(out.contains(".yarn/cache") || out.contains(".yarn\\cache"), "missing Yarn project cache. out=\n{}", out);
+
+    let (ok2, out2, err2) = run_with_env_and_cwd(
+        proj.path(),
+        &[("HOME", home)],
+        &["--list", "--json"],
+    );
+    assert!(ok2, "command (no --js-pm) failed on macOS. stderr=\n{}\nstdout=\n{}", err2, out2);
+
+    for needle in ["/.npm", "Library/pnpm/store/v3", "Library/Caches/pnpm", "Library/Caches/Yarn", ".yarn/cache"] {
+        if out2.contains(needle) { panic!("unexpected JS PM entry '{}' found without --js-pm. out=\n{}", needle, out2); }
+    }
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn js_pm_end_to_end_linux() {
+    let td = TempDir::new().unwrap();
+    let home = td.path();
+    // Seed expected Linux locations
+    fs::create_dir_all(home.join(".npm")).unwrap();
+    fs::create_dir_all(home.join(".local").join("share").join("pnpm").join("store").join("v3")).unwrap();
+    fs::create_dir_all(home.join(".cache").join("pnpm")).unwrap();
+    fs::create_dir_all(home.join(".cache").join("yarn")).unwrap();
+
+    let proj = TempDir::new().unwrap();
+    fs::create_dir_all(proj.path().join(".yarn").join("cache")).unwrap();
+
+    let (ok, out, err) = run_with_env_and_cwd(
+        proj.path(),
+        &[("HOME", home)],
+        &["--list", "--json", "--js-pm"],
+    );
+    assert!(ok, "command failed on Linux. stderr=\n{}\nstdout=\n{}", err, out);
+
+    assert!(out.contains("/.npm") || out.contains("\\.npm"), "missing ~/.npm entry. out=\n{}", out);
+    assert!(out.contains(".local/share/pnpm/store/v3") || out.contains(".local\\share\\pnpm\\store\\v3"), "missing pnpm store v3 entry. out=\n{}", out);
+    assert!(out.contains(".cache/pnpm") || out.contains(".cache\\pnpm"), "missing pnpm meta cache. out=\n{}", out);
+    assert!(out.contains(".cache/yarn") || out.contains(".cache\\yarn"), "missing Yarn global cache. out=\n{}", out);
+    assert!(out.contains(".yarn/cache") || out.contains(".yarn\\cache"), "missing Yarn project cache. out=\n{}", out);
+
+    let (ok2, out2, err2) = run_with_env_and_cwd(
+        proj.path(),
+        &[("HOME", home)],
+        &["--list", "--json"],
+    );
+    assert!(ok2, "command (no --js-pm) failed on Linux. stderr=\n{}\nstdout=\n{}", err2, out2);
+
+    for needle in ["/.npm", ".local/share/pnpm/store/v3", ".cache/pnpm", ".cache/yarn", ".yarn/cache"] {
+        if out2.contains(needle) { panic!("unexpected JS PM entry '{}' found without --js-pm. out=\n{}", needle, out2); }
+    }
+}

--- a/tests/js_pm_integration.rs
+++ b/tests/js_pm_integration.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+// Minimal smoke test to ensure the new --js-pm flag is wired into the CLI
+// and that it returns JSON (object) without errors.
+#[test]
+fn js_pm_list_json_succeeds_and_is_object() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--list", "--json", "--js-pm"])
+        .output()
+        .expect("failed to run cachekill");
+
+    assert!(output.status.success(), "command failed: status={:?}\nstdout=\n{}\nstderr=\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let s = stdout.trim();
+    assert!(s.starts_with("{"), "stdout should start with '{{' but was: {}", s);
+    assert!(s.ends_with("}"), "stdout should end with '}}' but was: {}", s);
+}


### PR DESCRIPTION
- Add support for handling JavaScript package manager caches (npm, pnpm, yarn)
- Created module `package_managers` with support for (npm, pnpm, yarn)
- Added reusable utilities to support adding new package managers in the future
- Added new `--js-pm` parameter
- These caches are not backed up (large sizes, 10GB+ in some cases, do not have any effect)
- Usage remains the same with an additional `--js-pm` parameter
- Add tests for JavaScript package manager support, including e2e and integration